### PR TITLE
Add a npm script for JavaScript bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "r.js -o rjs_config.js"
+  },
   "dependencies": {
     "@turf/turf": "^4.5.2",
     "argv": "0.0.2",


### PR DESCRIPTION
JavaScriptのバンドル作業を容易にするビルドコマンドのエイリアスとしてnpm scriptを追加しました。
`npm run build` で RequireJSが走ります。